### PR TITLE
feat(auth): enhance user authentication flow with Bearer token suppor…

### DIFF
--- a/app/(auth)/register/page.tsx
+++ b/app/(auth)/register/page.tsx
@@ -64,12 +64,16 @@ export default function RegisterPage() {
       return;
     }
 
-    if (data.user) {
-      // Persist profile in public.users
+    if (data.user && data.session) {
+      // Persist profile in public.users. The session cookies are not yet set
+      // on the server at this point, so we authenticate via the Bearer token.
       try {
         const response = await fetch("/api/users", {
           method: "POST",
-          headers: { "Content-Type": "application/json" },
+          headers: {
+            "Content-Type": "application/json",
+            Authorization: `Bearer ${data.session.access_token}`,
+          },
           body: JSON.stringify({
             id: data.user.id,
             name: values.name,
@@ -91,6 +95,8 @@ export default function RegisterPage() {
         return;
       }
     }
+    // If data.session is null, email confirmation is required.
+    // The /auth/callback route will create the profile after the user confirms.
 
     if (data.session) {
       window.location.href = "/dashboard";

--- a/app/api/users/route.ts
+++ b/app/api/users/route.ts
@@ -11,11 +11,20 @@ const bodySchema = z.object({
 });
 
 export async function POST(request: Request) {
-  // Verify the caller is authenticated as this user
   const supabase = await createClient();
+
+  // After signUp() the session cookie is not yet set, so we also accept a
+  // Bearer token that the client passes from the freshly-created session.
+  const authHeader = request.headers.get("authorization");
+  const bearerToken = authHeader?.startsWith("Bearer ")
+    ? authHeader.slice(7)
+    : null;
+
   const {
     data: { user },
-  } = await supabase.auth.getUser();
+  } = bearerToken
+    ? await supabase.auth.getUser(bearerToken)
+    : await supabase.auth.getUser();
 
   if (!user) {
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 });

--- a/proxy.ts
+++ b/proxy.ts
@@ -3,7 +3,7 @@ import { NextResponse, type NextRequest } from "next/server";
 
 const PUBLIC_PATHS = ["/login", "/register", "/auth/callback"];
 
-export async function middleware(request: NextRequest) {
+export async function proxy(request: NextRequest) {
   let supabaseResponse = NextResponse.next({ request });
 
   const supabase = createServerClient(


### PR DESCRIPTION
This pull request improves the user registration flow and authentication handling, particularly around the creation of user profiles immediately after sign-up. The main focus is on ensuring that the backend API can authenticate requests using a Bearer token when session cookies are not yet set, and clarifying the handling of email confirmation cases. Additionally, there is a minor refactor to rename the middleware function for clarity.

**Authentication and registration improvements:**

* The registration page now sends the Bearer token from the newly created session in the `Authorization` header when creating a user profile, ensuring the backend can authenticate the request even before session cookies are set.
* The `/api/users` endpoint now accepts a Bearer token for authentication in addition to the session cookie, allowing immediate profile creation after sign-up.
* Added a comment and logic to handle cases where email confirmation is required, deferring profile creation until after confirmation.

**Refactoring and code clarity:**

* Renamed the middleware function and file from `middleware.ts` to `proxy.ts`, and updated the function name from `middleware` to `proxy` for better clarity.